### PR TITLE
add XML Schema definition for the bundle configuration

### DIFF
--- a/DependencyInjection/AsmTranslationLoaderExtension.php
+++ b/DependencyInjection/AsmTranslationLoaderExtension.php
@@ -65,4 +65,20 @@ class AsmTranslationLoaderExtension extends Extension
             $loader->load('orm.xml');
         }
     }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getNamespace()
+    {
+        return 'https://github.com/maschmann/TranslationLoaderBundle/schema/dic';
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getXsdValidationBasePath()
+    {
+        return __DIR__.'/../Resources/config/schema';
+    }
 }

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -29,6 +29,7 @@ class Configuration implements ConfigurationInterface
         $supportedDrivers = array('orm');
 
         $rootNode
+            ->fixXmlConfig('resource')
             ->children()
                 ->arrayNode('resources')
                     ->useAttributeAsKey('locale')
@@ -52,7 +53,7 @@ class Configuration implements ConfigurationInterface
                 ->scalarNode('driver')
                     ->validate()
                         ->ifNotInArray($supportedDrivers)
-                        ->thenInvalid('The driver %s is not supported. Please choose on of '.json_encode($supportedDrivers))
+                        ->thenInvalid('The driver %s is not supported. Please choose one of '.json_encode($supportedDrivers))
                     ->end()
                     ->defaultValue('orm')
                     ->cannotBeEmpty()

--- a/Resources/config/schema/translation-loader-1.0.xsd
+++ b/Resources/config/schema/translation-loader-1.0.xsd
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<xsd:schema xmlns="https://github.com/maschmann/TranslationLoaderBundle/schema/dic"
+    xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+    targetNamespace="https://github.com/maschmann/TranslationLoaderBundle/schema/dic"
+    elementFormDefault="qualified"
+>
+    <xsd:element name="config" type="config" />
+
+    <xsd:complexType name="config">
+        <xsd:choice minOccurs="1" maxOccurs="unbounded">
+            <xsd:element name="resource" type="resource" />
+            <xsd:element name="database" type="database" />
+        </xsd:choice>
+        <xsd:attribute name="driver" type="xsd:string" />
+        <xsd:attribute name="history" type="xsd:boolean" />
+    </xsd:complexType>
+
+    <xsd:complexType name="resource">
+        <xsd:choice>
+            <xsd:element name="domain" type="xsd:string" minOccurs="0" maxOccurs="unbounded" />
+        </xsd:choice>
+        <xsd:attribute name="locale" type="xsd:string" use="required" />
+    </xsd:complexType>
+
+    <xsd:complexType name="database">
+        <xsd:attribute name="entity-manager" use="required" />
+    </xsd:complexType>
+</xsd:schema>


### PR DESCRIPTION
This adds an XML Schema Definition file for the bundle configuration.

With this you'll be able to configure the bundle using XML like this:

``` xml
<container xmlns="http://symfony.com/schema/dic/services"
    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
    xmlns:translation-loader="https://github.com/maschmann/TranslationLoaderBundle/schema/dic"
    xsi:schemaLocation="http://symfony.com/schema/dic/services
        http://symfony.com/schema/dic/services/services-1.0.xsd
        https://github.com/maschmann/TranslationLoaderBundle/schema/dic
        https://github.com/maschmann/TranslationLoaderBundle/schema/dic/translation-loader-1.0.xsd"
>
    <translation-loader:config driver="orm" history="false">
        <translation-loader:resource locale="fr">
            <translation-loader:domain>foo</translation-loader:domain>
            <translation-loader:domain>bar</translation-loader:domain>
        </translation-loader:resource>
        <translation-loader:resource locale="de">
            <translation-loader:domain>baz</translation-loader:domain>
        </translation-loader:resource>
        <translation-loader:resource locale="en" />

        <translation-loader:database entitiy-manager="default" />
    </translation-loader:config>
</container>
```

which is equivalent to the following YAML config:

``` yml
asm_translation_loader:
    resources:
        fr: [ foo, bar ]
        de: baz
        en: ~
    driver: orm
    history: false
    database:
        entity_manager: default
```

The only thing I guess where we should find a solution is which URL to use for the Namespace-URL (using `https://github.com/maschmann/TranslationLoaderBundle/schema/dic/translation-loader-1.0.xsd` is imho no good idea).
