### PR TITLE
make file loaders configurable per file extension

### DIFF
--- a/DependencyInjection/AsmTranslationLoaderExtension.php
+++ b/DependencyInjection/AsmTranslationLoaderExtension.php
@@ -41,6 +41,9 @@ class AsmTranslationLoaderExtension extends Extension
             $em = $config['database']['entity_manager'];
         }
 
+        // association between file extensions and translation loader service ids
+        $container->setParameter('asm_translation_loader.translation_loaders', $config['loaders']);
+
         // check if history feature is enabled
         $historyEnabled = false;
         if (isset($config['history']['enabled'])
@@ -64,6 +67,9 @@ class AsmTranslationLoaderExtension extends Extension
         if ('orm' == $config['driver']) {
             $loader->load('orm.xml');
         }
+
+        // load the loader resolver service
+        $loader->load('file_loader_resolver.xml');
     }
 
     /**

--- a/DependencyInjection/Compiler/RegisterFileLoadersPass.php
+++ b/DependencyInjection/Compiler/RegisterFileLoadersPass.php
@@ -1,0 +1,54 @@
+<?php
+
+/*
+ * This file is part of the AsmTranslationLoaderBundle package.
+ *
+ * (c) Marc Aschmann <maschmann@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Asm\TranslationLoaderBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+class RegisterFileLoadersPass implements CompilerPassInterface
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function process(ContainerBuilder $container)
+    {
+        if (!$container->hasDefinition('asm_translation_loader.file_loader_resolver')) {
+            return;
+        }
+
+        /** @var \Asm\TranslationLoaderBundle\Translation\FileLoaderResolver $fileLoader */
+        $fileLoader = $container->get('asm_translation_loader.file_loader_resolver');
+        $loaders = $container->findTaggedServiceIds('translation.loader');
+
+        foreach ($loaders as $id => $tagAttributes) {
+            $definition = $container->findDefinition($id);
+
+            // skip non file loaders
+            if (false === strpos($definition->getClass(), 'FileLoader')) {
+                continue;
+            }
+
+            foreach ($tagAttributes as $attributes) {
+                $fileLoader->registerLoader($attributes['alias'], $container->get($id));
+            }
+        }
+
+        // additional file loaders can be registered in the configuration
+        if ($container->hasParameter('asm_translation_loader.translation_loaders')) {
+            $additionalLoaders = $container->getParameter('asm_translation_loader.translation_loaders');
+
+            foreach ($additionalLoaders as $extension => $loaderId) {
+                $fileLoader->registerLoader($extension, $container->get($loaderId));
+            }
+        }
+    }
+}

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -30,6 +30,7 @@ class Configuration implements ConfigurationInterface
 
         $rootNode
             ->fixXmlConfig('resource')
+            ->fixXmlConfig('loader')
             ->children()
                 ->arrayNode('resources')
                     ->useAttributeAsKey('locale')
@@ -57,6 +58,29 @@ class Configuration implements ConfigurationInterface
                     ->end()
                     ->defaultValue('orm')
                     ->cannotBeEmpty()
+                ->end()
+                ->arrayNode('loaders')
+                    ->beforeNormalization()
+                        ->ifNull()
+                        ->then(function () { return array(); })
+                    ->end()
+                    ->beforeNormalization()
+                        ->always(function ($values) {
+                            foreach ($values as $key => $value) {
+                                if (is_array($value)) {
+                                    $values[$value['extension']] = $value['value'];
+                                    unset($values[$key]);
+                                }
+                            }
+
+                            return array_merge(array(
+                                'xlf' => 'translation.loader.xliff',
+                                'yaml' => 'translation.loader.yml',
+                            ), $values);
+                        })
+                    ->end()
+                    ->useAttributeAsKey('extension')
+                    ->prototype('scalar')->end()
                 ->end()
                 ->arrayNode('database')
                     ->children()

--- a/Resources/config/file_loader_resolver.xml
+++ b/Resources/config/file_loader_resolver.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" ?>
+<container xmlns="http://symfony.com/schema/dic/services"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://symfony.com/schema/dic/services
+        http://symfony.com/schema/dic/services/services-1.0.xsd"
+>
+    <parameters>
+        <parameter key="asm_translation_loader.file_loader_resolver.class">Asm\TranslationLoaderBundle\Translation\FileLoaderResolver</parameter>
+    </parameters>
+    <services>
+        <service id="asm_translation_loader.file_loader_resolver"
+            class="%asm_translation_loader.file_loader_resolver.class%"/>
+    </services>
+</container>

--- a/Resources/config/schema/translation-loader-1.0.xsd
+++ b/Resources/config/schema/translation-loader-1.0.xsd
@@ -10,6 +10,7 @@
         <xsd:choice minOccurs="1" maxOccurs="unbounded">
             <xsd:element name="resource" type="resource" />
             <xsd:element name="database" type="database" />
+            <xsd:element name="loader" type="loader" />
         </xsd:choice>
         <xsd:attribute name="driver" type="xsd:string" />
         <xsd:attribute name="history" type="xsd:boolean" />
@@ -24,5 +25,13 @@
 
     <xsd:complexType name="database">
         <xsd:attribute name="entity-manager" use="required" />
+    </xsd:complexType>
+
+    <xsd:complexType name="loader">
+        <xsd:simpleContent>
+            <xsd:extension base="xsd:string">
+                <xsd:attribute name="extension" use="required"/>
+            </xsd:extension>
+        </xsd:simpleContent>
     </xsd:complexType>
 </xsd:schema>

--- a/Tests/DependencyInjection/Compiler/RegisterFileLoadersPassTest.php
+++ b/Tests/DependencyInjection/Compiler/RegisterFileLoadersPassTest.php
@@ -1,0 +1,294 @@
+<?php
+
+/*
+ * This file is part of the AsmTranslationLoaderBundle package.
+ *
+ * (c) Marc Aschmann <maschmann@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Asm\TranslationLoaderBundle\Tests\DependencyInjection\Compiler;
+
+use Asm\TranslationLoaderBundle\DependencyInjection\Compiler\RegisterFileLoadersPass;
+use Asm\TranslationLoaderBundle\Model\TranslationInterface;
+use Asm\TranslationLoaderBundle\Model\TranslationManagerInterface;
+use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractCompilerPassTestCase;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Reference;
+
+/**
+ * @author Christian Flothmann <christian.flothmann@xabbuh.de>
+ */
+class RegisterFileLoadersPassTest extends AbstractCompilerPassTestCase
+{
+    public function testCsvFileloaderIsRegistered()
+    {
+        $this->bootstrapContainer();
+        $this->compile();
+        $fileLoaderResolver = $this->getFileLoaderResolver();
+
+        $this->assertInstanceOf(
+            'Symfony\Component\Translation\Loader\CsvFileLoader',
+            $fileLoaderResolver->resolveLoader('csv')
+        );
+    }
+
+    public function testDatFileloaderIsRegistered()
+    {
+        $this->bootstrapContainer();
+        $this->compile();
+        $fileLoaderResolver = $this->getFileLoaderResolver();
+
+        $this->assertInstanceOf(
+            'Symfony\Component\Translation\Loader\IcuDatFileLoader',
+            $fileLoaderResolver->resolveLoader('dat')
+        );
+    }
+
+    public function testDatabaseLoaderIsNotRegistered()
+    {
+        $this->bootstrapContainer();
+        $this->compile();
+        $fileLoaderResolver = $this->getFileLoaderResolver();
+
+        $this->assertNull($fileLoaderResolver->resolveLoader('db'));
+    }
+
+    public function testIniFileloaderIsRegistered()
+    {
+        $this->bootstrapContainer();
+        $this->compile();
+        $fileLoaderResolver = $this->getFileLoaderResolver();
+
+        $this->assertInstanceOf(
+            'Symfony\Component\Translation\Loader\IniFileLoader',
+            $fileLoaderResolver->resolveLoader('ini')
+        );
+    }
+
+    public function testMoFileloaderIsRegistered()
+    {
+        $this->bootstrapContainer();
+        $this->compile();
+        $fileLoaderResolver = $this->getFileLoaderResolver();
+
+        $this->assertInstanceOf(
+            'Symfony\Component\Translation\Loader\MoFileLoader',
+            $fileLoaderResolver->resolveLoader('mo')
+        );
+    }
+
+    public function testPhpFileloaderIsRegistered()
+    {
+        $this->bootstrapContainer();
+        $this->compile();
+        $fileLoaderResolver = $this->getFileLoaderResolver();
+
+        $this->assertInstanceOf(
+            'Symfony\Component\Translation\Loader\PhpFileLoader',
+            $fileLoaderResolver->resolveLoader('php')
+        );
+    }
+
+    public function testPoFileloaderIsRegistered()
+    {
+        $this->bootstrapContainer();
+        $this->compile();
+        $fileLoaderResolver = $this->getFileLoaderResolver();
+
+        $this->assertInstanceOf(
+            'Symfony\Component\Translation\Loader\PoFileLoader',
+            $fileLoaderResolver->resolveLoader('po')
+        );
+    }
+
+    public function testQtFileloaderIsRegistered()
+    {
+        $this->bootstrapContainer();
+        $this->compile();
+        $fileLoaderResolver = $this->getFileLoaderResolver();
+
+        $this->assertInstanceOf(
+            'Symfony\Component\Translation\Loader\QtFileLoader',
+            $fileLoaderResolver->resolveLoader('qt')
+        );
+    }
+
+    public function testResFileloaderIsRegistered()
+    {
+        $this->bootstrapContainer();
+        $this->compile();
+        $fileLoaderResolver = $this->getFileLoaderResolver();
+
+        $this->assertInstanceOf(
+            'Symfony\Component\Translation\Loader\IcuResFileLoader',
+            $fileLoaderResolver->resolveLoader('res')
+        );
+    }
+
+    public function testXliffFileloaderIsRegistered()
+    {
+        $this->bootstrapContainer();
+        $this->compile();
+        $fileLoaderResolver = $this->getFileLoaderResolver();
+
+        $this->assertInstanceOf(
+            'Symfony\Component\Translation\Loader\XliffFileLoader',
+            $fileLoaderResolver->resolveLoader('xliff')
+        );
+    }
+
+    public function testYmlFileloaderIsRegistered()
+    {
+        $this->bootstrapContainer();
+        $this->compile();
+        $fileLoaderResolver = $this->getFileLoaderResolver();
+
+        $this->assertInstanceOf(
+            'Symfony\Component\Translation\Loader\YamlFileLoader',
+            $fileLoaderResolver->resolveLoader('yml')
+        );
+    }
+
+    public function testAdditionalFileExtensionsAreRegistered()
+    {
+        $this->bootstrapContainer();
+        $this->setParameter('asm_translation_loader.translation_loaders', array(
+            'xlf' => 'translation.loader.xliff',
+            'yaml' => 'translation.loader.yml',
+        ));
+        $this->compile();
+        $fileLoaderResolver = $this->getFileLoaderResolver();
+
+        $this->assertInstanceOf(
+            'Symfony\Component\Translation\Loader\XliffFileLoader',
+            $fileLoaderResolver->resolveLoader('xlf')
+        );
+        $this->assertInstanceOf(
+            'Symfony\Component\Translation\Loader\YamlFileLoader',
+            $fileLoaderResolver->resolveLoader('yaml')
+        );
+    }
+
+    public function testStandardFileLoadersCanBeReplaced()
+    {
+        $this->bootstrapContainer();
+        $this->setParameter('asm_translation_loader.translation_loaders', array(
+            'yml' => 'translation.loader.csv',
+        ));
+        $this->compile();
+        $fileLoaderResolver = $this->getFileLoaderResolver();
+
+        $this->assertInstanceOf(
+            'Symfony\Component\Translation\Loader\CsvFileLoader',
+            $fileLoaderResolver->resolveLoader('yml')
+        );
+    }
+
+    protected function registerCompilerPass(ContainerBuilder $container)
+    {
+        $container->addCompilerPass(new RegisterFileLoadersPass());
+    }
+
+    private function bootstrapContainer()
+    {
+        $fileLoaderResolver = new Definition('Asm\TranslationLoaderBundle\Translation\FileLoaderResolver');
+        $this->setDefinition('asm_translation_loader.file_loader_resolver', $fileLoaderResolver);
+
+        $translationManager = new Definition(
+            '\Asm\TranslationLoaderBundle\Tests\DependencyInjection\Compiler\DummyTranslationManager'
+        );
+        $this->setDefinition('asm_translation_loader.translation_manager', $translationManager);
+        $loaders = array(
+            'csv' => array(
+                'class' => 'Symfony\Component\Translation\Loader\CsvFileLoader',
+            ),
+            'dat' => array(
+                'class' => 'Symfony\Component\Translation\Loader\IcuDatFileLoader',
+            ),
+            'db' => array(
+                'class' => 'Asm\TranslationLoaderBundle\Translation\DatabaseLoader',
+                'arguments' => array(
+                    new Reference('asm_translation_loader.translation_manager')
+                )
+            ),
+            'ini' => array(
+                'class' => 'Symfony\Component\Translation\Loader\IniFileLoader',
+            ),
+            'mo' => array(
+                'class' => 'Symfony\Component\Translation\Loader\MoFileLoader',
+            ),
+            'php' => array(
+                'class' => 'Symfony\Component\Translation\Loader\PhpFileLoader',
+            ),
+            'po' => array(
+                'class' => 'Symfony\Component\Translation\Loader\PoFileLoader',
+            ),
+            'qt' => array(
+                'class' => 'Symfony\Component\Translation\Loader\QtFileLoader',
+            ),
+            'res' => array(
+                'class' => 'Symfony\Component\Translation\Loader\IcuResFileLoader',
+            ),
+            'xliff' => array(
+                'class' => 'Symfony\Component\Translation\Loader\XliffFileLoader',
+            ),
+            'yml' => array(
+                'class' => 'Symfony\Component\Translation\Loader\YamlFileLoader',
+            ),
+        );
+
+        foreach ($loaders as $alias => $attributes) {
+            $loader = new Definition($attributes['class']);
+
+            if (isset($attributes['arguments'])) {
+                $loader->setArguments($attributes['arguments']);
+            }
+
+            $loader->addTag('translation.loader', array('alias' => $alias));
+            $this->setDefinition('translation.loader.'.$alias, $loader);
+        }
+    }
+
+    /**
+     * @return \Asm\TranslationLoaderBundle\Translation\FileLoaderResolver
+     */
+    private function getFileLoaderResolver()
+    {
+        return $this->container->get('asm_translation_loader.file_loader_resolver');
+    }
+}
+
+class DummyTranslationManager implements TranslationManagerInterface
+{
+    public function createTranslation()
+    {
+    }
+
+    public function findTranslationBy(array $criteria)
+    {
+    }
+
+    public function findAllTranslations()
+    {
+    }
+
+    public function findTranslationsBy(array $criteria)
+    {
+    }
+
+    public function findTranslationsByLocaleAndDomain($locale, $domain = 'messages')
+    {
+    }
+
+    public function updateTranslation(TranslationInterface $translation)
+    {
+    }
+
+    public function removeTranslation(TranslationInterface $translation)
+    {
+    }
+}

--- a/Tests/DependencyInjection/ConfigurationTest.php
+++ b/Tests/DependencyInjection/ConfigurationTest.php
@@ -11,30 +11,16 @@
 
 namespace Asm\TranslationLoaderBundle\Tests\DependencyInjection;
 
+use Asm\TranslationLoaderBundle\DependencyInjection\AsmTranslationLoaderExtension;
 use Asm\TranslationLoaderBundle\DependencyInjection\Configuration;
+use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractExtensionConfigurationTestCase;
 use Symfony\Component\Config\Definition\Processor;
 
 /**
  * @author Christian Flothmann <christian.flothmann@xabbuh.de>
  */
-class ConfigurationTest extends \PHPUnit_Framework_TestCase
+class ConfigurationTest extends AbstractExtensionConfigurationTestCase
 {
-    /**
-     * @var Configuration
-     */
-    private $configuration;
-
-    /**
-     * @var Processor
-     */
-    private $processor;
-
-    protected function setUp()
-    {
-        $this->configuration = new Configuration();
-        $this->processor = new Processor();
-    }
-
     public function testLocaleWithoutDomain()
     {
         $configs = $this->buildResourcesConfig(array('en' => null));
@@ -88,9 +74,87 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(array('en' => array('foo', 'bar')), $config['resources']);
     }
 
+    public function testAdditionalLoaderFromXml()
+    {
+        $this->assertProcessedConfigurationEquals(
+            array(
+                'resources' => array(),
+                'driver' => 'orm',
+                'loaders' => array(
+                    'foo' => 'translation.loader.bar',
+                    'xlf' => 'translation.loader.xliff',
+                    'yaml' => 'translation.loader.yml',
+                ),
+                'history' => array('enabled' => false),
+            ),
+            array(__DIR__.'/Fixtures/additional_loader.xml')
+        );
+    }
+
+    public function testAdditionalLoaderFromYaml()
+    {
+        $this->assertProcessedConfigurationEquals(
+            array(
+                'resources' => array(),
+                'driver' => 'orm',
+                'loaders' => array(
+                    'foo' => 'translation.loader.bar',
+                    'xlf' => 'translation.loader.xliff',
+                    'yaml' => 'translation.loader.yml',
+                ),
+                'history' => array('enabled' => false),
+            ),
+            array(__DIR__.'/Fixtures/additional_loader.yml')
+        );
+    }
+
+    public function testReplacedLoaderFromXml()
+    {
+        $this->assertProcessedConfigurationEquals(
+            array(
+                'resources' => array(),
+                'driver' => 'orm',
+                'loaders' => array(
+                    'xlf' => 'translation.loader.xliff',
+                    'yaml' => 'translation.loader.foo',
+                ),
+                'history' => array('enabled' => false),
+            ),
+            array(__DIR__.'/Fixtures/replaced_loader.xml')
+        );
+    }
+
+    public function testReplacedLoaderFromYml()
+    {
+        $this->assertProcessedConfigurationEquals(
+            array(
+                'resources' => array(),
+                'driver' => 'orm',
+                'loaders' => array(
+                    'xlf' => 'translation.loader.xliff',
+                    'yaml' => 'translation.loader.foo',
+                ),
+                'history' => array('enabled' => false),
+            ),
+            array(__DIR__.'/Fixtures/replaced_loader.yml')
+        );
+    }
+
+    protected function getContainerExtension()
+    {
+        return new AsmTranslationLoaderExtension();
+    }
+
+    protected function getConfiguration()
+    {
+        return new Configuration();
+    }
+
     private function process(array $configs)
     {
-        return $this->processor->processConfiguration($this->configuration, $configs);
+        $processor = new Processor();
+
+        return $processor->processConfiguration($this->getConfiguration(), $configs);
     }
 
     private function buildResourcesConfig(array $resources)
@@ -102,4 +166,3 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
         );
     }
 }
- 

--- a/Tests/DependencyInjection/Fixtures/additional_loader.xml
+++ b/Tests/DependencyInjection/Fixtures/additional_loader.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" ?>
+<container xmlns="http://symfony.com/schema/dic/services"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:asm-translation-loader="https://github.com/maschmann/TranslationLoaderBundle/schema/dic"
+    xsi:schemaLocation="http://symfony.com/schema/dic/services
+        http://symfony.com/schema/dic/services/services-1.0.xsd
+        https://github.com/maschmann/TranslationLoaderBundle/schema/dic
+        https://github.com/maschmann/TranslationLoaderBundle/schema/dic/translation-loader-1.0.xsd"
+>
+    <asm-translation-loader:config>
+        <asm-translation-loader:loader extension="foo">translation.loader.bar</asm-translation-loader:loader>
+    </asm-translation-loader:config>
+</container>

--- a/Tests/DependencyInjection/Fixtures/additional_loader.yml
+++ b/Tests/DependencyInjection/Fixtures/additional_loader.yml
@@ -1,0 +1,3 @@
+asm_translation_loader:
+    loaders:
+        foo: translation.loader.bar

--- a/Tests/DependencyInjection/Fixtures/replaced_loader.xml
+++ b/Tests/DependencyInjection/Fixtures/replaced_loader.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" ?>
+<container xmlns="http://symfony.com/schema/dic/services"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:asm-translation-loader="https://github.com/maschmann/TranslationLoaderBundle/schema/dic"
+    xsi:schemaLocation="http://symfony.com/schema/dic/services
+        http://symfony.com/schema/dic/services/services-1.0.xsd
+        https://github.com/maschmann/TranslationLoaderBundle/schema/dic
+        https://github.com/maschmann/TranslationLoaderBundle/schema/dic/translation-loader-1.0.xsd"
+>
+    <asm-translation-loader:config>
+        <asm-translation-loader:loader extension="yaml">translation.loader.foo</asm-translation-loader:loader>
+    </asm-translation-loader:config>
+</container>

--- a/Tests/DependencyInjection/Fixtures/replaced_loader.yml
+++ b/Tests/DependencyInjection/Fixtures/replaced_loader.yml
@@ -1,0 +1,3 @@
+asm_translation_loader:
+    loaders:
+        yaml: translation.loader.foo

--- a/Translation/FileLoaderResolver.php
+++ b/Translation/FileLoaderResolver.php
@@ -1,0 +1,65 @@
+<?php
+
+/*
+ * This file is part of the AsmTranslationLoaderBundle package.
+ *
+ * (c) Marc Aschmann <maschmann@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Asm\TranslationLoaderBundle\Translation;
+
+use Symfony\Component\Translation\Loader\LoaderInterface;
+
+/**
+ * Translation loader resolver.
+ *
+ * @author Christian Flothmann <christian.flothmann@xabbuh.de>
+ */
+class FileLoaderResolver
+{
+    /**
+     * @var LoaderInterface[]
+     */
+    private $loaders = array();
+
+    /**
+     * @param string          $extension The file extension
+     * @param LoaderInterface $loader    The translation loader
+     */
+    public function registerLoader($extension, LoaderInterface $loader)
+    {
+        $this->loaders[$extension] = $loader;
+    }
+
+    /**
+     * Checks whether or not a translation loader for a file extension is registered.
+     *
+     * @param string $extension The file extension
+     *
+     * @return boolean True if such a loader is registered, false otherwise
+     */
+    public function hasLoader($extension)
+    {
+        return isset($this->loaders[$extension]);
+    }
+
+    /**
+     * Resolves the translation loader for a file extension.
+     *
+     * @param string $extension The file extension
+     *
+     * @return LoaderInterface The resolved loader or null if no loader is
+     *                         associated with the given extension
+     */
+    public function resolveLoader($extension)
+    {
+        if ($this->hasLoader($extension)) {
+            return $this->loaders[$extension];
+        }
+
+        return null;
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,7 @@
         "symfony/translation": "~2.2"
     },
     "require-dev": {
+        "matthiasnoback/symfony-dependency-injection-test": "~0.6",
         "symfony/framework-bundle": "~2.2",
         "symfony/security-bundle": "~2.2"
     },


### PR DESCRIPTION
Inspired by #17 I decided to implement a file loader resolver. Besides resolving the standard translation file loaders (plus file loaders for the `.xlf` and `.yaml` extension), users can register their custom file extensions.
