### PR TITLE
resolve a circular reference, fixes #20

### DIFF
--- a/AsmTranslationLoaderBundle.php
+++ b/AsmTranslationLoaderBundle.php
@@ -3,8 +3,10 @@
 namespace Asm\TranslationLoaderBundle;
 
 use Asm\TranslationLoaderBundle\DependencyInjection\Compiler\AddResourcePass;
+use Symfony\Component\DependencyInjection\Compiler\PassConfig;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
+use Symfony\Component\HttpKernel\DependencyInjection\RegisterListenersPass;
 
 class AsmTranslationLoaderBundle extends Bundle
 {
@@ -16,5 +18,10 @@ class AsmTranslationLoaderBundle extends Bundle
         parent::build($container);
 
         $container->addCompilerPass(new AddResourcePass());
+        $container->addCompilerPass(new RegisterListenersPass(
+            'asm_translation_loader.event_dispatcher',
+            'asm_translation_loader.event_listener',
+            'asm_translation_loader.event_subscriber'
+        ), PassConfig::TYPE_BEFORE_REMOVING);
     }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 CHANGELOG
 =========
 
+* resolve circular dependency between the `doctrine.orm.default_entity_manager`
+  (or any other Doctrine ORM entity manager service) and `security_context` services
+  when using the translation history feature
+
 * disable the Form and Validator extension when running tests to be compatible with
   Symfony 2.5.4
 

--- a/DependencyInjection/AsmTranslationLoaderExtension.php
+++ b/DependencyInjection/AsmTranslationLoaderExtension.php
@@ -50,6 +50,9 @@ class AsmTranslationLoaderExtension extends Extension
             new FileLocator(__DIR__.'/../Resources/config')
         );
 
+        // load the event dispatcher
+        $loader->load('event_dispatcher.xml');
+
         // load the translation manager resource
         $container->setParameter('asm_translation_loader.resources', $config['resources']);
         $loader->load('translation_manager_resource.xml');

--- a/Doctrine/TranslationHistoryManager.php
+++ b/Doctrine/TranslationHistoryManager.php
@@ -1,0 +1,60 @@
+<?php
+
+/*
+ * This file is part of the AsmTranslationLoaderBundle package.
+ *
+ * (c) Marc Aschmann <maschmann@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Asm\TranslationLoaderBundle\Doctrine;
+
+use Asm\TranslationLoaderBundle\Model\TranslationHistoryInterface;
+use Asm\TranslationLoaderBundle\Model\TranslationHistoryManager as BaseTranslationHistoryManager;
+use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\Common\Persistence\ObjectRepository;
+
+/**
+ * TranslationHistoryManager implementation supporting Doctrine.
+ *
+ * @author Christian Flothmann <christian.flothmann@xabbuh.de>
+ */
+class TranslationHistoryManager extends BaseTranslationHistoryManager
+{
+    /**
+     * @var ObjectManager
+     */
+    private $objectManager;
+
+    /**
+     * @var ObjectRepository
+     */
+    private $repository;
+
+    /**
+     * @param ObjectManager $objectManager Object manager for translation history entities
+     * @param string        $class         Translation history model class name
+     */
+    public function __construct(ObjectManager $objectManager, $class)
+    {
+        parent::__construct($class);
+
+        $this->objectManager = $objectManager;
+        $this->repository = $objectManager->getRepository($class);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function updateTranslationHistory(TranslationHistoryInterface $translationHistory, $clear = false)
+    {
+        $this->objectManager->persist($translationHistory);
+        $this->objectManager->flush();
+
+        if ($clear) {
+            $this->objectManager->clear();
+        }
+    }
+}

--- a/Event/TranslationEvent.php
+++ b/Event/TranslationEvent.php
@@ -1,0 +1,46 @@
+<?php
+
+/*
+ * This file is part of the AsmTranslationLoaderBundle package.
+ *
+ * (c) Marc Aschmann <maschmann@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Asm\TranslationLoaderBundle\Event;
+
+use Asm\TranslationLoaderBundle\Model\TranslationInterface;
+use Symfony\Component\EventDispatcher\Event;
+
+/**
+ * Event that is triggered through a {@link TranslationInterface translation's}
+ * lifecycle.
+ *
+ * @author Christian Flothmann <christian.flothmann@xabbuh.de>
+ */
+class TranslationEvent extends Event
+{
+    const POST_PERSIST = 'postPersist';
+    const POST_UPDATE = 'postUpdate';
+    const POST_REMOVE = 'postRemove';
+
+    /**
+     * @var TranslationInterface
+     */
+    private $translation;
+
+    public function __construct(TranslationInterface $translation)
+    {
+        $this->translation = $translation;
+    }
+
+    /**
+     * @return TranslationInterface
+     */
+    public function getTranslation()
+    {
+        return $this->translation;
+    }
+}

--- a/EventListener/TranslationHistorySubscriber.php
+++ b/EventListener/TranslationHistorySubscriber.php
@@ -1,106 +1,72 @@
 <?php
-/**
- * @namespace
+
+/*
+ * This file is part of the AsmTranslationLoaderBundle package.
+ *
+ * (c) Marc Aschmann <maschmann@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
  */
+
 namespace Asm\TranslationLoaderBundle\EventListener;
 
-use Doctrine\Common\EventSubscriber;
-use Doctrine\ORM\Event\LifecycleEventArgs;
-use Asm\TranslationLoaderBundle\Entity\Translation;
-use Asm\TranslationLoaderBundle\Entity\TranslationHistory;
+use Asm\TranslationLoaderBundle\Event\TranslationEvent;
+use Asm\TranslationLoaderBundle\Model\TranslationHistoryInterface;
+use Asm\TranslationLoaderBundle\Model\TranslationHistoryManagerInterface;
+use Symfony\Component\Security\Core\SecurityContextInterface;
 
 /**
  * Class TranslationHistorySubscriber
  *
- * @package Asm\TranslationLoaderBundle\EventListener
  * @author marc aschmann <maschmann@gmail.com>
- * @uses Doctrine\Common\EventSubscriber
- * @uses Doctrine\ORM\Event\LifecycleEventArgs
- * @uses Asm\TranslationLoaderBundle\Entity\Translation
- * @uses Asm\TranslationLoaderBundle\Entity\TranslationHistory
+ * @author Christian Flothmann <christian.flothmann@xabbuh.de>
  */
-class TranslationHistorySubscriber implements EventSubscriber
+class TranslationHistorySubscriber
 {
     /**
-     * @var \Symfony\Component\Security\Core\SecurityContext $securityContext
+     * @var TranslationHistoryManagerInterface
+     */
+    private $translationHistoryManager;
+
+    /**
+     * @var SecurityContextInterface
      */
     private $securityContext;
 
-    /**
-     * @return array
-     */
-    public function getSubscribedEvents()
+    public function __construct(TranslationHistoryManagerInterface $translationHistoryManager, SecurityContextInterface $securityContext)
     {
-        return array(
-            'postPersist',
-            'postUpdate',
-            'postRemove',
-        );
-    }
-
-    /**
-     * @param LifecycleEventArgs $args
-     */
-    public function postUpdate(LifecycleEventArgs $args)
-    {
-        $this->index($args, 'update');
-    }
-
-    /**
-     * @param LifecycleEventArgs $args
-     */
-    public function postPersist(LifecycleEventArgs $args)
-    {
-        $this->index($args, 'persist');
-    }
-
-    /**
-     * @param LifecycleEventArgs $args
-     */
-    public function postRemove(LifecycleEventArgs $args)
-    {
-        $this->index($args, 'remove');
-    }
-
-    /**
-     * @param LifecycleEventArgs $args
-     * @param string $type type of event
-     */
-    public function index(LifecycleEventArgs $args, $type)
-    {
-        $entity        = $args->getEntity();
-        $entityManager = $args->getEntityManager();
-
-        if ($entity instanceof Translation) {
-
-            $token    = $this->securityContext->getToken();
-            $userName = 'anonymous';
-            if (!empty($token)) {
-                $userName = $token->getUsername();
-            }
-
-            /** @var \Asm\TranslationLoaderBundle\Entity\TranslationHistory $historyEvent */
-            $historyEvent = new TranslationHistory();
-            $historyEvent->setTransKey($entity->getTransKey());
-            $historyEvent->setTransLocale($entity->getTransLocale());
-            $historyEvent->setMessageDomain($entity->getMessageDomain());
-            $historyEvent->setTranslation($entity->getTranslation());
-            $historyEvent->setUserAction($type);
-            $historyEvent->setUserName($userName);
-            $historyEvent->setDateOfChange(new \DateTime());
-
-            $entityManager->persist($historyEvent);
-            $entityManager->flush();
-            $entityManager->detach($historyEvent);
-            $entityManager->clear();
-        }
-    }
-
-    /**
-     * @param $securityContext
-     */
-    public function setSecurityContext($securityContext)
-    {
+        $this->translationHistoryManager = $translationHistoryManager;
         $this->securityContext = $securityContext;
+    }
+
+    /**
+     * Event-based update of the translation history.
+     *
+     * @param TranslationEvent $event The event triggering the update
+     *
+     * @return TranslationHistoryInterface The new translation history entry
+     */
+    public function updateHistory(TranslationEvent $event)
+    {
+        $translation = $event->getTranslation();
+
+        $historyEntry = $this->translationHistoryManager->createTranslationHistory();
+        $historyEntry->setDateOfChange(new \DateTime());
+        $historyEntry->setMessageDomain($translation->getMessageDomain());
+        $historyEntry->setTransKey($translation->getTransKey());
+        $historyEntry->setTransLocale($translation->getTransLocale());
+        $historyEntry->setTranslation($translation->getTranslation());
+        $historyEntry->setUserAction(strtolower(substr($event->getName(), 4)));
+
+        if (null !== $token = $this->securityContext->getToken()) {
+            $historyEntry->setUserName($token->getUsername());
+        } else {
+            $historyEntry->setUserName('anonymous');
+        }
+
+        $this->translationHistoryManager->updateTranslationHistory($historyEntry);
+
+        return $historyEntry;
     }
 }

--- a/Model/TranslationHistoryManager.php
+++ b/Model/TranslationHistoryManager.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ * This file is part of the AsmTranslationLoaderBundle package.
+ *
+ * (c) Marc Aschmann <maschmann@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Asm\TranslationLoaderBundle\Model;
+
+/**
+ * Base {@link TranslationHistoryManagerInterface} implementation (can be extended
+ * by concrete implementations).
+ *
+ * @author Christian Flothmann <christian.flothmann@xabbuh.de>
+ */
+abstract class TranslationHistoryManager implements TranslationHistoryManagerInterface
+{
+    /**
+     * Class implementing the {@link TranslationHistoryInterface} managed by this
+     * manager
+     * @var string
+     */
+    protected $class;
+
+    /**
+     * @param string $class Class name of managed {@link TranslationHistoryInterface}
+     *                      objects
+     */
+    public function __construct($class)
+    {
+        $this->class = $class;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function createTranslationHistory()
+    {
+        return new $this->class();
+    }
+}

--- a/Model/TranslationHistoryManagerInterface.php
+++ b/Model/TranslationHistoryManagerInterface.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * This file is part of the AsmTranslationLoaderBundle package.
+ *
+ * (c) Marc Aschmann <maschmann@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Asm\TranslationLoaderBundle\Model;
+
+/**
+ * Interface definition for classes that manage {@link TranslationHistoryInterface}
+ * objects.
+ *
+ * @author Christian Flothmann <christian.flothmann@xabbuh.de>
+ */
+interface TranslationHistoryManagerInterface
+{
+    /**
+     * Creates a new {@link TranslationHistoryInterface} instance.
+     *
+     * @return TranslationHistoryInterface The new translation history entry
+     */
+    public function createTranslationHistory();
+
+    /**
+     * Writes a new or modified translation history to the underlying storage.
+     *
+     * @param TranslationHistoryInterface $translationHistory The translation history entry to update
+     * @param bool                        $clear              Whether or not to clear the manager for performance reasons
+     *                                                        after the entry has been processed
+     */
+    public function updateTranslationHistory(TranslationHistoryInterface $translationHistory, $clear = false);
+}

--- a/Model/TranslationManager.php
+++ b/Model/TranslationManager.php
@@ -11,6 +11,8 @@
 
 namespace Asm\TranslationLoaderBundle\Model;
 
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+
 /**
  * Base {@link TranslationManagerInterface} implementation (can be extended by
  * concrete implementations).
@@ -26,12 +28,19 @@ abstract class TranslationManager implements TranslationManagerInterface
     protected $class;
 
     /**
-     * @param string $class Class name of managed {@link TranslationInterface}
-     *                      objects
+     * @var EventDispatcherInterface
      */
-    public function __construct($class)
+    protected $eventDispatcher;
+
+    /**
+     * @param string                   $class           Class name of managed {@link TranslationInterface} objects
+     * @param EventDispatcherInterface $eventDispatcher Event dispatcher used to propagate new, modified
+     *                                                  and removed translations
+     */
+    public function __construct($class, EventDispatcherInterface $eventDispatcher)
     {
         $this->class = $class;
+        $this->eventDispatcher = $eventDispatcher;
     }
 
     /**

--- a/Resources/config/event_dispatcher.xml
+++ b/Resources/config/event_dispatcher.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<container xmlns="http://symfony.com/schema/dic/services"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://symfony.com/schema/dic/services
+        http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <parameters>
+        <parameter key="asm_translation_loader.event_dispatcher.class">Symfony\Component\EventDispatcher\ContainerAwareEventDispatcher</parameter>
+    </parameters>
+
+    <services>
+        <service
+            id="asm_translation_loader.event_dispatcher"
+            class="%asm_translation_loader.event_dispatcher.class%">
+
+            <argument type="service" id="service_container" />
+        </service>
+    </services>
+</container>

--- a/Resources/config/orm.xml
+++ b/Resources/config/orm.xml
@@ -2,23 +2,36 @@
 <container xmlns="http://symfony.com/schema/dic/services"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://symfony.com/schema/dic/services
-        http://symfony.com/schema/dic/services/services-1.0.xsd"
->
+        http://symfony.com/schema/dic/services/services-1.0.xsd">
+
     <parameters>
         <parameter key="asm_translation_loader.translation_manager.class">Asm\TranslationLoaderBundle\Doctrine\TranslationManager</parameter>
+        <parameter key="asm_translation_loader.translation_history_manager.class">Asm\TranslationLoaderBundle\Doctrine\TranslationHistoryManager</parameter>
         <parameter key="asm_translation_loader.model.translation.class">Asm\TranslationLoaderBundle\Entity\Translation</parameter>
+        <parameter key="asm_translation_loader.model.translation_history.class">Asm\TranslationLoaderBundle\Entity\TranslationHistory</parameter>
     </parameters>
+
     <services>
         <service id="asm_translation_loader.translation_manager" class="%asm_translation_loader.translation_manager.class%">
             <argument type="service" id="asm_translation_loader.translation.entity_manager" />
             <argument>%asm_translation_loader.model.translation.class%</argument>
+            <argument type="service" id="asm_translation_loader.event_dispatcher" />
         </service>
+
+        <service
+            id="asm_translation_loader.translation_history_manager"
+            class="%asm_translation_loader.translation_history_manager.class%">
+
+            <argument type="service" id="asm_translation_loader.translation.entity_manager" />
+            <argument>%asm_translation_loader.model.translation_history.class%</argument>
+        </service>
+
         <service id="asm_translation_loader.translation.entity_manager"
             class="Doctrine\Common\Persistence\ObjectManager"
             factory-service="doctrine"
             factory-method="getManager"
-            public="false"
-        >
+            public="false">
+
             <argument>%asm_translation_loader.database.entity_manager%</argument>
         </service>
     </services>

--- a/Resources/config/translation_history_subscriber.xml
+++ b/Resources/config/translation_history_subscriber.xml
@@ -13,8 +13,22 @@
             id="asm_translation_loader.history.subscriber"
             class="%asm_translation_loader.history.subscriber.class%">
 
+            <argument type="service" id="asm_translation_loader.translation_history_manager" />
             <argument type="service" id="security.context" />
-            <tag name="doctrine.event_subscriber" />
+            <tag
+                name="asm_translation_loader.event_listener"
+                event="postPersist"
+                method="updateHistory" />
+
+            <tag
+                name="asm_translation_loader.event_listener"
+                event="postUpdate"
+                method="updateHistory" />
+
+            <tag
+                name="asm_translation_loader.event_listener"
+                event="postRemove"
+                method="updateHistory" />
         </service>
     </services>
 </container>

--- a/Tests/AsmTranslationLoaderBundleTest.php
+++ b/Tests/AsmTranslationLoaderBundleTest.php
@@ -1,0 +1,46 @@
+<?php
+
+/*
+ * This file is part of the AsmTranslationLoaderBundle package.
+ *
+ * (c) Marc Aschmann <maschmann@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Asm\TranslationLoaderBundle\Tests;
+
+use Asm\TranslationLoaderBundle\AsmTranslationLoaderBundle;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\HttpKernel\DependencyInjection\RegisterListenersPass;
+
+/**
+ * @author Christian Flothmann <christian.flothmann@xabbuh.de>
+ */
+class AsmTranslationLoaderBundleTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var AsmTranslationLoaderBundle
+     */
+    private $bundle;
+
+    protected function setUp()
+    {
+        $this->bundle = new AsmTranslationLoaderBundle();
+    }
+
+    public function testBuild()
+    {
+        $container = new ContainerBuilder();
+        $this->bundle->build($container);
+        $passes = $container->getCompilerPassConfig()->getBeforeRemovingPasses();
+        $expectedPass = new RegisterListenersPass(
+            'asm_translation_loader.event_dispatcher',
+            'asm_translation_loader.event_listener',
+            'asm_translation_loader.event_subscriber'
+        );
+
+        $this->assertEquals($expectedPass, $passes[0]);
+    }
+}

--- a/Tests/Doctrine/TranslationHistoryManagerTest.php
+++ b/Tests/Doctrine/TranslationHistoryManagerTest.php
@@ -1,0 +1,118 @@
+<?php
+
+/*
+ * This file is part of the AsmTranslationLoaderBundle package.
+ *
+ * (c) Marc Aschmann <maschmann@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Asm\TranslationLoaderBundle\Tests\Doctrine;
+
+use Asm\TranslationLoaderBundle\Doctrine\TranslationHistoryManager;
+use Asm\TranslationLoaderBundle\Entity\TranslationHistory;
+use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\ORM\EntityRepository;
+
+/**
+ * @author Christian Flothmann <christian.flothmann@xabbuh.de>
+ */
+class TranslationHistoryManagerTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var EntityRepository|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $repository;
+
+    /**
+     * @var ObjectManager|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $objectManager;
+
+    /**
+     * @var TranslationHistoryManager
+     */
+    private $translationManager;
+
+    protected function setUp()
+    {
+        $this->createObjectManager();
+        $this->translationManager = new TranslationHistoryManager(
+            $this->objectManager,
+            'Asm\TranslationLoaderBundle\Entity\TranslationHistory'
+        );
+    }
+
+    public function testCreateTranslationHistory()
+    {
+        $translation = $this->translationManager->createTranslationHistory();
+        $this->assertInstanceOf('Asm\TranslationLoaderBundle\Entity\TranslationHistory', $translation);
+    }
+
+    public function testUpdateTranslationHistory()
+    {
+        $translation = $this->createTranslationHistory();
+        $this->objectManager
+            ->expects($this->once())
+            ->method('persist')
+            ->with($this->equalTo($translation));
+        $this->objectManager
+            ->expects($this->once())
+            ->method('flush');
+        $this
+            ->objectManager
+            ->expects($this->never())
+            ->method('clear');
+
+        $this->translationManager->updateTranslationHistory($translation);
+    }
+
+    public function testUpdateTranslationHistoryAndClear()
+    {
+        $translation = $this->createTranslationHistory();
+        $this->objectManager
+            ->expects($this->once())
+            ->method('persist')
+            ->with($this->equalTo($translation));
+        $this->objectManager
+            ->expects($this->once())
+            ->method('flush');
+        $this
+            ->objectManager
+            ->expects($this->once())
+            ->method('clear');
+
+        $this->translationManager->updateTranslationHistory($translation, true);
+    }
+
+    private function createRepository()
+    {
+        $this->repository = $this->getMock(
+            'Doctrine\ORM\EntityRepository',
+            array(),
+            array(),
+            '',
+            false
+        );
+    }
+
+    private function createObjectManager()
+    {
+        $this->createRepository();
+        $this->objectManager = $this->getMock('Doctrine\Common\Persistence\ObjectManager');
+        $this->objectManager
+            ->expects($this->any())
+            ->method('getRepository')
+            ->will($this->returnValue($this->repository));
+    }
+
+    /**
+     * @return TranslationHistory|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private function createTranslationHistory()
+    {
+        return $this->getMock('Asm\TranslationLoaderBundle\Entity\TranslationHistory');
+    }
+}

--- a/Tests/Doctrine/TranslationManagerTest.php
+++ b/Tests/Doctrine/TranslationManagerTest.php
@@ -13,10 +13,11 @@ namespace Asm\TranslationLoaderBundle\Tests\Doctrine;
 
 use Asm\TranslationLoaderBundle\Doctrine\TranslationManager;
 use Asm\TranslationLoaderBundle\Entity\Translation;
+use Asm\TranslationLoaderBundle\Tests\Model\TranslationManagerTest as BaseTranslationManagerTest;
 use Doctrine\Common\Persistence\ObjectManager;
 use Doctrine\ORM\EntityRepository;
 
-class TranslationManagerTest extends \PHPUnit_Framework_TestCase
+class TranslationManagerTest extends BaseTranslationManagerTest
 {
     /**
      * @var EntityRepository|\PHPUnit_Framework_MockObject_MockObject
@@ -27,20 +28,6 @@ class TranslationManagerTest extends \PHPUnit_Framework_TestCase
      * @var ObjectManager|\PHPUnit_Framework_MockObject_MockObject
      */
     private $objectManager;
-
-    /**
-     * @var TranslationManager
-     */
-    private $translationManager;
-
-    protected function setUp()
-    {
-        $this->createObjectManager();
-        $this->translationManager = new TranslationManager(
-            $this->objectManager,
-            'Asm\TranslationLoaderBundle\Entity\Translation'
-        );
-    }
 
     public function testCreateTranslation()
     {
@@ -134,6 +121,43 @@ class TranslationManagerTest extends \PHPUnit_Framework_TestCase
             ->method('flush');
 
         $this->translationManager->removeTranslation($translation);
+    }
+
+    protected function createTranslationManager()
+    {
+        $this->createObjectManager();
+
+        return new TranslationManager(
+            $this->objectManager,
+            'Asm\TranslationLoaderBundle\Entity\Translation',
+            $this->eventDispatcher
+        );
+    }
+
+    protected function createFreshTranslation()
+    {
+        $translation = new Translation();
+        $this
+            ->objectManager
+            ->expects($this->any())
+            ->method('contains')
+            ->with($translation)
+            ->willReturn(false);
+
+        return $translation;
+    }
+
+    protected function createNonFreshTranslation()
+    {
+        $translation = new Translation();
+        $this
+            ->objectManager
+            ->expects($this->any())
+            ->method('contains')
+            ->with($translation)
+            ->willReturn(true);
+
+        return $translation;
     }
 
     private function createRepository()

--- a/Tests/EventListener/TranslationHistorySubscriberTest.php
+++ b/Tests/EventListener/TranslationHistorySubscriberTest.php
@@ -1,0 +1,163 @@
+<?php
+
+/*
+ * This file is part of the AsmTranslationLoaderBundle package.
+ *
+ * (c) Marc Aschmann <maschmann@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Asm\TranslationLoaderBundle\Tests\EventListener;
+
+use Asm\TranslationLoaderBundle\Event\TranslationEvent;
+use Asm\TranslationLoaderBundle\EventListener\TranslationHistorySubscriber;
+use Asm\TranslationLoaderBundle\Model\Translation;
+use Asm\TranslationLoaderBundle\Model\TranslationHistory;
+use Asm\TranslationLoaderBundle\Model\TranslationHistoryManagerInterface;
+use Symfony\Component\Security\Core\SecurityContextInterface;
+
+/**
+ * @author Christian Flothmann <christian.flothmann@xabbuh.de>
+ */
+class TranslationHistorySubscriberTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var TranslationHistoryManagerInterface|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $translationHistoryManager;
+
+    protected function setUp()
+    {
+        $this->translationHistoryManager = $this->createTranslationHistoryManager();
+    }
+
+    /**
+     * @dataProvider updateHistoryProvider
+     */
+    public function testUpdateHistoryProvider($securityContext, $eventName, $expectedUsername, $expectedAction)
+    {
+        $dateBefore = new \DateTime();
+        $translation = $this->createRandomDummyTranslation();
+        $subscriber = new TranslationHistorySubscriber($this->translationHistoryManager, $securityContext);
+        $this
+            ->translationHistoryManager
+            ->expects($this->once())
+            ->method('updateTranslationHistory')
+            ->with($this->isInstanceOf('Asm\TranslationLoaderBundle\Model\TranslationHistoryInterface'), false);
+        $event = new TranslationEvent($translation);
+        $event->setName($eventName);
+        $translationHistory = $subscriber->updateHistory($event);
+
+        $this->assertGreaterThanOrEqual($dateBefore, $translationHistory->getDateOfChange());
+        $this->assertEquals($translation->getMessageDomain(), $translationHistory->getMessageDomain());
+        $this->assertEquals($translation->getTransKey(), $translationHistory->getTransKey());
+        $this->assertEquals($translation->getTransLocale(), $translationHistory->getTransLocale());
+        $this->assertEquals($translation->getTranslation(), $translationHistory->getTranslation());
+        $this->assertEquals($expectedUsername, $translationHistory->getUserName());
+        $this->assertEquals($expectedAction, $translationHistory->getUserAction());
+    }
+
+    public function updateHistoryProvider()
+    {
+        return array(
+            'persist-anonymous-user' => array(
+                $this->createAnonymousSecurityContext(),
+                TranslationEvent::POST_PERSIST,
+                'anonymous',
+                'persist',
+            ),
+            'update-anonymous-user' => array(
+                $this->createAnonymousSecurityContext(),
+                TranslationEvent::POST_UPDATE,
+                'anonymous',
+                'update',
+            ),
+            'remove-anonymous-user' => array(
+                $this->createAnonymousSecurityContext(),
+                TranslationEvent::POST_REMOVE,
+                'anonymous',
+                'remove',
+            ),
+            'persist-authenticated-user' => array(
+                $this->createAuthenticatedSecurityContext(),
+                TranslationEvent::POST_PERSIST,
+                'the username',
+                'persist',
+            ),
+            'update-authenticated-user' => array(
+                $this->createAuthenticatedSecurityContext(),
+                TranslationEvent::POST_UPDATE,
+                'the username',
+                'update',
+            ),
+            'remove-authenticated-user' => array(
+                $this->createAuthenticatedSecurityContext(),
+                TranslationEvent::POST_REMOVE,
+                'the username',
+                'remove',
+            ),
+        );
+    }
+
+    /**
+     * @return TranslationHistoryManagerInterface|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private function createTranslationHistoryManager()
+    {
+        $manager = $this->getMock('Asm\TranslationLoaderBundle\Model\TranslationHistoryManagerInterface');
+        $manager
+            ->expects($this->any())
+            ->method('createTranslationHistory')
+            ->will($this->returnValue(new DummyTranslationHistory()));
+
+        return $manager;
+    }
+
+    /**
+     * @return SecurityContextInterface|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private function createAnonymousSecurityContext()
+    {
+        return $this->getMock('Symfony\Component\Security\Core\SecurityContextInterface');
+    }
+
+    /**
+     * @return SecurityContextInterface|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private function createAuthenticatedSecurityContext()
+    {
+        $token = $this->getMock('Symfony\Component\Security\Core\Authentication\Token\TokenInterface');
+        $token
+            ->expects($this->any())
+            ->method('getUsername')
+            ->will($this->returnValue('the username'));
+        $securityContext = $this->getMock('Symfony\Component\Security\Core\SecurityContextInterface');
+        $securityContext
+            ->expects($this->any())
+            ->method('getToken')
+            ->will($this->returnValue($token));
+
+        return $securityContext;
+    }
+
+    private function createRandomDummyTranslation()
+    {
+        $translation = new DummyTranslation();
+        $translation->setTransKey(md5(uniqid()));
+        $translation->setTransLocale(md5(uniqid()));
+        $translation->setMessageDomain(md5(uniqid()));
+        $translation->setTranslation(md5(uniqid()));
+
+        return $translation;
+    }
+}
+
+class DummyTranslation extends Translation
+{
+}
+
+class DummyTranslationHistory extends TranslationHistory
+{
+}

--- a/Tests/Model/TranslationManagerTest.php
+++ b/Tests/Model/TranslationManagerTest.php
@@ -1,0 +1,90 @@
+<?php
+
+/*
+ * This file is part of the AsmTranslationLoaderBundle package.
+ *
+ * (c) Marc Aschmann <maschmann@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Asm\TranslationLoaderBundle\Tests\Model;
+
+use Asm\TranslationLoaderBundle\Event\TranslationEvent;
+use Asm\TranslationLoaderBundle\Model\TranslationInterface;
+use Asm\TranslationLoaderBundle\Model\TranslationManagerInterface;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+
+/**
+ * @author Christian Flothmann <christian.flothmann@xabbuh.de>
+ */
+abstract class TranslationManagerTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var TranslationManagerInterface
+     */
+    protected $translationManager;
+
+    /**
+     * @var EventDispatcherInterface|\PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $eventDispatcher;
+
+    protected function setUp()
+    {
+        $this->eventDispatcher = $this->getMock('Symfony\Component\EventDispatcher\EventDispatcherInterface');
+        $this->translationManager = $this->createTranslationManager();
+    }
+
+    public function testPostPersistEventIsDispatched()
+    {
+        $translation = $this->createFreshTranslation();
+        $expectedEvent = new TranslationEvent($translation);
+        $this
+            ->eventDispatcher
+            ->expects($this->once())
+            ->method('dispatch')
+            ->with(TranslationEvent::POST_PERSIST, $this->equalTo($expectedEvent));
+        $this->translationManager->updateTranslation($translation);
+    }
+
+    public function testPostUpdateEventIsDispatched()
+    {
+        $translation = $this->createNonFreshTranslation();
+        $expectedEvent = new TranslationEvent($translation);
+        $this
+            ->eventDispatcher
+            ->expects($this->once())
+            ->method('dispatch')
+            ->with(TranslationEvent::POST_UPDATE, $this->equalTo($expectedEvent));
+        $this->translationManager->updateTranslation($translation);
+    }
+
+    public function testPostRemoveEventIsDispatched()
+    {
+        $translation = $this->createNonFreshTranslation();
+        $expectedEvent = new TranslationEvent($translation);
+        $this
+            ->eventDispatcher
+            ->expects($this->once())
+            ->method('dispatch')
+            ->with(TranslationEvent::POST_REMOVE, $this->equalTo($expectedEvent));
+        $this->translationManager->removeTranslation($translation);
+    }
+
+    /**
+     * @return TranslationManagerInterface
+     */
+    abstract protected function createTranslationManager();
+
+    /**
+     * @return TranslationInterface
+     */
+    abstract protected function createFreshTranslation();
+
+    /**
+     * @return TranslationInterface
+     */
+    abstract protected function createNonFreshTranslation();
+}

--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,7 @@
         "symfony/config": "~2.2",
         "symfony/console": "~2.2",
         "symfony/dependency-injection": "~2.2",
+        "symfony/event-dispatcher": "~2.2",
         "symfony/filesystem": "~2.2",
         "symfony/finder": "~2.2",
         "symfony/http-kernel": "~2.2",


### PR DESCRIPTION
When the history subscriber of the bundle is enabled and a firewall uses an entity user provider, there is a circular reference. Now, the subscriber no longer makes use of Doctrine's event system. Instead, the bundle creates its own event subsystem. Events are now dispatched by the translation manager implementations of the database driver to which the history subscriber is listening.
