### PR TITLE
don't allow PHP 7 builds to fail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,6 @@ matrix:
   fast_finish: true
   allow_failures:
     - php: hhvm
-    - php: 7.0
   include:
     - php: 5.4
     - php: 5.4


### PR DESCRIPTION
PHP 7 is now stable and tests must pass with this version.