### PR TITLE
improve Travis CI build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,9 +15,9 @@ matrix:
   allow_failures:
     - php: hhvm
   include:
-    - php: 5.4
-    - php: 5.4
+    - php: 5.3
       env: deps="low"
+    - php: 5.4
     - php: 5.5
     - php: 5.6
       env: SYMFONY_VERSION="2.3.x"
@@ -34,7 +34,12 @@ matrix:
     - php: 7.0
     - php: hhvm
 
-before_script:
+before_install:
   - if [ "$SYMFONY_VERSION" != "" ]; then composer require symfony/symfony:${SYMFONY_VERSION} --dev --no-update; fi
+
+install:
   - if [ "$deps" = "" ]; then composer install; fi
   - if [ "$deps" = "low" ]; then composer update --prefer-lowest; fi
+
+before_script:
+  - if [ "$COVERAGE" != "yes" -a "$TRAVIS_PHP_VERSION" != "hhvm" ]; then phpenv config-rm xdebug.ini; fi


### PR DESCRIPTION
* Run lowest possible deps jobs on PHP 5.3.
* Disable xdebug when code coverage reports are not generated.
* Properly use `before_install` and `install` steps in Travis config.