### PR TITLE
even Composer should be executed without xdebug

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,11 +35,9 @@ matrix:
     - php: hhvm
 
 before_install:
+  - if [ "$COVERAGE" != "yes" -a "$TRAVIS_PHP_VERSION" != "hhvm" ]; then phpenv config-rm xdebug.ini; fi
   - if [ "$SYMFONY_VERSION" != "" ]; then composer require symfony/symfony:${SYMFONY_VERSION} --dev --no-update; fi
 
 install:
   - if [ "$deps" = "" ]; then composer install; fi
   - if [ "$deps" = "low" ]; then composer update --prefer-lowest; fi
-
-before_script:
-  - if [ "$COVERAGE" != "yes" -a "$TRAVIS_PHP_VERSION" != "hhvm" ]; then phpenv config-rm xdebug.ini; fi


### PR DESCRIPTION
The changes in #31 are not good enough. Even Composer operations should
be performed without Xdebug being enabled.